### PR TITLE
Debug hydration mismatch in scanner input

### DIFF
--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -735,6 +735,7 @@ export default function Scanner() {
           <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "center" }}>
             <span style={{ opacity: 0.8, fontSize: 12 }}>Want to save your cans? give your name</span>
             <input
+              suppressHydrationWarning
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="Enter your name"


### PR DESCRIPTION
Add `suppressHydrationWarning` to the username input to prevent hydration mismatch caused by browser extension-injected attributes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b21af29a-89dc-4ee7-834e-fac322197aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b21af29a-89dc-4ee7-834e-fac322197aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

